### PR TITLE
Add definition of count variable to mode().

### DIFF
--- a/statistics.py
+++ b/statistics.py
@@ -57,7 +57,7 @@ def mode(data):
         data = list(data)
     data = sorted(data)
     last = modev = None
-    countmax = i = 0
+    countmax = i = count =0
     while i < len(data):
         if data[i] == last:
             count += 1


### PR DESCRIPTION
Thanks for making and sharing this library (some time ago) !
I'm looking to use it on a project using ruff linter and it threw out a error about `count` being undefined in `mode()`. 

I think in normal usage the `count = 1` would get run before the `count += 1` however it's safer to have the variable defined ahead of time either way.

On a separate note, I _really_ like the look of this library, it's very clean and light. Would you be interested in submitting it to [micropython-lib](https://github.com/micropython/micropython-lib) (or me submitting it on your behalf, maintaining your git autohorship)?
